### PR TITLE
Update options.php

### DIFF
--- a/options.php
+++ b/options.php
@@ -7,6 +7,7 @@ $relativeUri = '/stats';
 // Set all allowed URI which should be accessible trough the proxy
 $whitelist = [
     '/js/script.js',
+    '/js/plausible.outbound-links.js',
     '/api/event'
 ];
 


### PR DESCRIPTION
The WordPress plugin loads `plausible.outbound-links.js` by default, so I'd add it to the whitelist.