### PR TITLE
Improve IN/OUT headers support

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ $backendUrl = "https://plausible.io";
 ## Contributors
 * Jonathan Nessier (@YogurtRocks), [Neoflow](https://www.neoflow.ch)
 * David Mondok (@davidmondok)
+* Julien Tessier (@julienmru), [Utile](https://www.utile.co)
 
 If you would like to see this reverse proxy for Plausible Analytics develop further, or if you want to support me or show me your appreciation, please
 donate any amount through PayPal. Thank you! :beers:


### PR DESCRIPTION
Hello !

[Headers are not case sensitive](https://www.rfc-editor.org/rfc/rfc2616#section-4.2), so I updated the code not to transmit `Host`, `Accept-Encoding`, `X-Forwarded-For`, `Client-IP` no matter the case.

I added support to pass original selected headers back to the client, for improved security and performance (eg. to allow the client to cache the JS files). As a consequence, I remove the hard-coded `Access-Control-Allow-Origin` / `Access-Control-Allow-Credentials` because they are sent by origin.

Of course, this is open to discussion.

Thanks.